### PR TITLE
Add support for parser object to `parserOptions.parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ module.exports = {
 }
 ```
 
+When using JavaScript configuration (`.eslintrc.js`), you can also give the parser object directly.
+
+```js
+const tsParser = require("@typescript-eslint/parser")
+
+module.exports = {
+    parser: "astro-eslint-parser",
+    parserOptions: {
+        parser: tsParser,
+    },
+}
+```
+
 ## :computer: Editor Integrations
 
 ### Visual Studio Code

--- a/explorer-v3/astro.config.mjs
+++ b/explorer-v3/astro.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
         "escape-string-regexp": resolve(
           "./build-system/shim/escape-string-regexp/index.js"
         ),
+        resolve: resolve("./build-system/shim/resolve.js"),
       },
     },
     build: {

--- a/explorer-v3/build-system/pre-build/webpack.config.js
+++ b/explorer-v3/build-system/pre-build/webpack.config.js
@@ -99,8 +99,8 @@ export default [
           test: /context\/resolve-parser\/index\.js$/u,
           loader: "string-replace-loader",
           options: {
-            search: /require\(name\)/gu.source,
-            replace: () => "__non_webpack_require__(name)",
+            search: /require\(parserValue\)/gu.source,
+            replace: () => "__non_webpack_require__(parserValue)",
             flags: "g",
           },
         },

--- a/explorer-v3/build-system/pre-build/webpack.config.js
+++ b/explorer-v3/build-system/pre-build/webpack.config.js
@@ -93,19 +93,6 @@ export default [
     entry: {
       "astro-eslint-parser": resolve("./astro-eslint-parser.js"),
     },
-    module: {
-      rules: [
-        {
-          test: /context\/resolve-parser\/index\.js$/u,
-          loader: "string-replace-loader",
-          options: {
-            search: /require\(parserValue\)/gu.source,
-            replace: () => "__non_webpack_require__(parserValue)",
-            flags: "g",
-          },
-        },
-      ],
-    },
     externals: {
       espree: "$$inject_espree$$",
       pako: "$$inject_pako$$",

--- a/explorer-v3/build-system/shim/resolve.js
+++ b/explorer-v3/build-system/shim/resolve.js
@@ -1,0 +1,7 @@
+export default {
+  sync,
+};
+
+export function sync(p) {
+  return p;
+}

--- a/explorer-v3/src/components/AstExplorer.svelte
+++ b/explorer-v3/src/components/AstExplorer.svelte
@@ -23,15 +23,13 @@ let b = 2;
   let jsonEditor, sourceEditor;
 
   let waiting = true;
+  let tsParser = undefined;
 
   $: language = filePath?.endsWith(".md") ? "markdown" : "astro";
   if (typeof window !== "undefined")
     window.waitSetupForAstroCompilerWasm
       .then(async () => {
-        const parser = await import("@typescript-eslint/parser");
-        if (typeof window !== "undefined") {
-          window.require.define("@typescript-eslint/parser", parser);
-        }
+        tsParser = await import("@typescript-eslint/parser");
       })
       .then(() => {
         waiting = false;
@@ -61,7 +59,7 @@ let b = 2;
     const start = Date.now();
     try {
       ast = astroEslintParser.parseForESLint(astroValue, {
-        parser: "@typescript-eslint/parser",
+        parser: tsParser,
         filePath,
       }).ast;
     } catch (e) {

--- a/explorer-v3/src/components/ESLintPlayground.svelte
+++ b/explorer-v3/src/components/ESLintPlayground.svelte
@@ -9,12 +9,10 @@
   import { DEFAULT_RULES_CONFIG, getURL } from "./scripts/rules.js";
 
   let linter = null;
+  let tsParser;
 
   async function setupLinter() {
-    const parser = await import("@typescript-eslint/parser");
-    if (typeof window !== "undefined") {
-      window.require.define("@typescript-eslint/parser", parser);
-    }
+    tsParser = await import("@typescript-eslint/parser");
     const linter = new Linter();
     linter.defineParser("astro-eslint-parser", astroEslintParser);
     for (const [id, rule] of Object.entries(pluginReact.rules)) {
@@ -130,7 +128,7 @@ let b = 2;
           parserOptions: {
             ecmaVersion: 2020,
             sourceType: "module",
-            parser: "@typescript-eslint/parser",
+            parser: tsParser,
           },
           rules,
           env: {

--- a/src/context/resolve-parser/espree.ts
+++ b/src/context/resolve-parser/espree.ts
@@ -1,8 +1,8 @@
 import { createRequire } from "module"
 import path from "path"
-import type { ESLintCustomParser } from "../../types"
+import type { BasicParserObject } from "./parser-object"
 
-let espreeCache: ESLintCustomParser | null = null
+let espreeCache: BasicParserObject | null = null
 
 /** Checks if given path is linter path */
 function isLinterPath(p: string): boolean {
@@ -20,7 +20,7 @@ function isLinterPath(p: string): boolean {
  * Load `espree` from the loaded ESLint.
  * If the loaded ESLint was not found, just returns `require("espree")`.
  */
-export function getEspree(): ESLintCustomParser {
+export function getEspree(): BasicParserObject {
     if (!espreeCache) {
         // Lookup the loaded eslint
         const linterPath = Object.keys(require.cache || {}).find(isLinterPath)

--- a/src/context/resolve-parser/index.ts
+++ b/src/context/resolve-parser/index.ts
@@ -1,18 +1,26 @@
-import type { ESLintCustomParser } from "../../types"
 import { getEspree } from "./espree"
+import type { ParserObject } from "./parser-object"
+import { isParserObject } from "./parser-object"
 
-/** Get parser name */
-export function getParserName(
+type UserOptionParser =
+    | string
+    | ParserObject
+    | Record<string, string | ParserObject | undefined>
+    | undefined
+
+/** Get parser for script lang */
+export function getParserForLang(
     attrs: Record<string, string | undefined>,
-    parser: any,
-): string {
+    parser: UserOptionParser,
+): string | ParserObject {
     if (parser) {
-        if (typeof parser === "string" && parser !== "espree") {
+        if (typeof parser === "string" || isParserObject(parser)) {
             return parser
-        } else if (typeof parser === "object") {
-            const name = parser[attrs.lang || "js"]
-            if (typeof name === "string") {
-                return getParserName(attrs, name)
+        }
+        if (typeof parser === "object") {
+            const value = parser[attrs.lang || "js"]
+            if (typeof value === "string" || isParserObject(value)) {
+                return value
             }
         }
     }
@@ -23,11 +31,14 @@ export function getParserName(
 export function getParser(
     attrs: Record<string, string | undefined>,
     parser: any,
-): ESLintCustomParser {
-    const name = getParserName(attrs, parser)
-    if (name !== "espree") {
+): ParserObject {
+    const parserValue = getParserForLang(attrs, parser)
+    if (isParserObject(parserValue)) {
+        return parserValue
+    }
+    if (parserValue !== "espree") {
         // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
-        return require(name)
+        return require(parserValue)
     }
     return getEspree()
 }

--- a/src/context/resolve-parser/parser-object.ts
+++ b/src/context/resolve-parser/parser-object.ts
@@ -1,0 +1,55 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import type { ESLintExtendedProgram } from "../../types"
+import type * as tsESLintParser from "@typescript-eslint/parser"
+type TSESLintParser = typeof tsESLintParser
+/**
+ * The type of basic ESLint custom parser.
+ * e.g. espree
+ */
+export type BasicParserObject = {
+    parse(code: string, options: any): TSESTree.Program
+    parseForESLint: undefined
+}
+/**
+ * The type of ESLint custom parser enhanced for ESLint.
+ * e.g. @babel/eslint-parser, @typescript-eslint/parser
+ */
+export type EnhancedParserObject = {
+    parseForESLint(code: string, options: any): ESLintExtendedProgram
+    parse: undefined
+}
+
+/**
+ * The type of ESLint (custom) parsers.
+ */
+export type ParserObject = EnhancedParserObject | BasicParserObject
+
+/** Checks whether given object is ParserObject */
+export function isParserObject(value: unknown): value is ParserObject {
+    return isEnhancedParserObject(value) || isBasicParserObject(value)
+}
+/** Checks whether given object is EnhancedParserObject */
+export function isEnhancedParserObject(
+    value: unknown,
+): value is EnhancedParserObject {
+    return Boolean(value && typeof (value as any).parseForESLint === "function")
+}
+/** Checks whether given object is BasicParserObject */
+export function isBasicParserObject(
+    value: unknown,
+): value is BasicParserObject {
+    return Boolean(value && typeof (value as any).parse === "function")
+}
+
+/** Checks whether given object is "@typescript-eslint/parser" */
+export function maybeTSESLintParserObject(
+    value: unknown,
+): value is TSESLintParser {
+    return (
+        isEnhancedParserObject(value) &&
+        isBasicParserObject(value) &&
+        typeof (value as any).createProgram === "function" &&
+        typeof (value as any).clearCaches === "function" &&
+        typeof (value as any).version === "string"
+    )
+}

--- a/src/parser/astro-parser/parse.ts
+++ b/src/parser/astro-parser/parse.ts
@@ -124,6 +124,9 @@ function fixLocations(node: ParentNode, ctx: Context): void {
                     "---",
                     start,
                 )
+                if (!node.position!.end) {
+                    node.position!.end = {} as any
+                }
                 start = node.position!.end!.offset =
                     tokenIndex(ctx, "---", start + 3 + node.value.length) + 3
             } else if (

--- a/src/parser/script.ts
+++ b/src/parser/script.ts
@@ -4,6 +4,7 @@ import type { ParserOptionsContext } from "../context/parser-options"
 import type { ESLintExtendedProgram } from "../types"
 import { tsPatch } from "./ts-patch"
 import type { ParserOptions } from "@typescript-eslint/types"
+import { isEnhancedParserObject } from "../context/resolve-parser/parser-object"
 /**
  * Parse for script
  */
@@ -31,9 +32,9 @@ export function parseScript(
         ) {
             patchResult = tsPatch(scriptParserOptions)
         }
-        const result =
-            parser.parseForESLint?.(code, scriptParserOptions) ??
-            parser.parse?.(code, scriptParserOptions)
+        const result = isEnhancedParserObject(parser)
+            ? parser.parseForESLint(code, scriptParserOptions)
+            : parser.parse(code, scriptParserOptions)
 
         if ("ast" in result && result.ast != null) {
             return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,3 @@ export interface ESLintExtendedProgram {
 export type ESLintCustomParserResult =
     | ESLintExtendedProgram["ast"]
     | ESLintExtendedProgram
-//
-// The interface of ESLint custom parsers.
-//
-export interface ESLintCustomParser {
-    parse(code: string, options: any): ESLintCustomParserResult
-    parseForESLint?(code: string, options: any): ESLintCustomParserResult
-}

--- a/tests/src/parser/parser-options.ts
+++ b/tests/src/parser/parser-options.ts
@@ -1,0 +1,39 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import assert from "assert"
+import { parseForESLint } from "../../../src"
+import * as tsParser from "@typescript-eslint/parser"
+
+const CODE = `---
+a<b|c>(d);
+---`
+
+function parse(code: string, options: any) {
+    return parseForESLint(code, options).ast
+}
+
+describe("parser options", () => {
+    describe("parserOptions.parser", () => {
+        it("should work without parser.", () => {
+            const ast = parse(CODE, {})
+
+            const st = ast.body[0] as TSESTree.ExpressionStatement
+            assert.strictEqual(st.expression.type, "BinaryExpression")
+        })
+        it("should work with parser name.", () => {
+            const ast = parse(CODE, {
+                parser: "@typescript-eslint/parser",
+            })
+
+            const st = ast.body[0] as TSESTree.ExpressionStatement
+            assert.strictEqual(st.expression.type, "CallExpression")
+        })
+        it("should work with single parser object.", () => {
+            const ast = parse(CODE, {
+                parser: tsParser,
+            })
+
+            const st = ast.body[0] as TSESTree.ExpressionStatement
+            assert.strictEqual(st.expression.type, "CallExpression")
+        })
+    })
+})


### PR DESCRIPTION
This PR changes `parserOptions.parser` to allow you to directly specify a parser object.

The new usage is described in the README.

<details>

> When using JavaScript configuration (`.eslintrc.js`), you can also give the parser object directly.
> 
> ```js
> const tsParser = require("@typescript-eslint/parser")
> module.exports = {
>     parser: "astro-eslint-parser",
>     parserOptions: {
>         parser: tsParser,
>     },
> }
> ```

</details>

As background, ESLint core is planning a new flat configuration.
https://eslint.org/blog/2022/08/new-config-system-part-1/

The new configuration allows you to specify parser objects directly.
https://eslint.org/blog/2022/08/new-config-system-part-2/#custom-parsers-and-parser-options-are-mostly-the-same

For this reason, there is a possibility that parsers that do not assume module name specification as before will appear.
The changes in this PR are intended to follow the new parser specification method.

However, you cannot use the custom parser provided by the plugin by name. Because the plugin configuration is not accessible from the parser options.
https://eslint.org/blog/2022/08/new-config-system-part-2/#custom-parsers-in-plugins