### PR TITLE
feat!: make node version support more strict

### DIFF
--- a/.changeset/olive-ducks-matter.md
+++ b/.changeset/olive-ducks-matter.md
@@ -1,0 +1,5 @@
+---
+"astro-eslint-parser": major
+---
+
+feat!: make node version support more strict

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "scripts": {
     "prebuild": "npm run -s clean",


### PR DESCRIPTION
We need this change to use the latest version of espree.