### PR TITLE
feat: replace fast-glob and is-glob with tinyglobby

### DIFF
--- a/.changeset/cold-glasses-end.md
+++ b/.changeset/cold-glasses-end.md
@@ -1,0 +1,7 @@
+---
+"astro-eslint-parser": minor
+---
+
+Replace fast-glob and is-glob with tinyglobby. 
+
+This improves performance and reduces the number of transitive dependencies by 17.

--- a/explorer-v3/astro.config.mjs
+++ b/explorer-v3/astro.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig({
           "./build-system/shim/astro-eslint-parser/index.js",
         ),
         "fast-glob": resolve("./build-system/shim/fast-glob.js"),
+        tinyglobby: resolve("./build-system/shim/tinyglobby.js"),
         tslib: resolve("../node_modules/tslib/tslib.es6.js"),
         "escape-string-regexp": resolve(
           "./build-system/shim/escape-string-regexp/index.js",

--- a/explorer-v3/astro.config.mjs
+++ b/explorer-v3/astro.config.mjs
@@ -25,7 +25,6 @@ export default defineConfig({
         "astro-eslint-parser": resolve(
           "./build-system/shim/astro-eslint-parser/index.js",
         ),
-        "fast-glob": resolve("./build-system/shim/fast-glob.js"),
         tinyglobby: resolve("./build-system/shim/tinyglobby.js"),
         tslib: resolve("../node_modules/tslib/tslib.es6.js"),
         "escape-string-regexp": resolve(

--- a/explorer-v3/build-system/pre-build/webpack.config.js
+++ b/explorer-v3/build-system/pre-build/webpack.config.js
@@ -18,7 +18,6 @@ const alias = {
   url: resolve("../shim/url.js"),
   util: resolve("../shim/util.js"),
   typescript: resolve("../shim/typescript.js"),
-  "fast-glob": resolve("../shim/fast-glob.js"),
   tinyglobby: resolve("../shim/tinyglobby.js"),
 };
 

--- a/explorer-v3/build-system/pre-build/webpack.config.js
+++ b/explorer-v3/build-system/pre-build/webpack.config.js
@@ -19,6 +19,7 @@ const alias = {
   util: resolve("../shim/util.js"),
   typescript: resolve("../shim/typescript.js"),
   "fast-glob": resolve("../shim/fast-glob.js"),
+  tinyglobby: resolve("../shim/tinyglobby.js"),
 };
 
 function getBase(name) {

--- a/explorer-v3/build-system/shim/fast-glob.js
+++ b/explorer-v3/build-system/shim/fast-glob.js
@@ -1,4 +1,0 @@
-export default { sync };
-export function sync() {
-  // noop
-}

--- a/explorer-v3/build-system/shim/tinyglobby.js
+++ b/explorer-v3/build-system/shim/tinyglobby.js
@@ -1,0 +1,7 @@
+export default { globSync, isDynamicPattern };
+export function globSync() {
+  // noop
+}
+export function isDynamicPattern() {
+  // noop
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
         "espree": "^11.2.0",
-        "fast-glob": "^3.3.3",
         "is-glob": "^4.0.3",
         "semver": "^7.3.8",
         "tinyglobby": "^0.2.17"
@@ -2997,6 +2996,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3010,6 +3010,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3019,6 +3020,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -4964,6 +4966,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -7728,6 +7731,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7744,6 +7748,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7787,6 +7792,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7851,6 +7857,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -8637,6 +8644,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -10963,6 +10971,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -11604,6 +11613,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -11617,6 +11627,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13138,6 +13149,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13493,6 +13505,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -13769,6 +13782,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14764,6 +14778,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "espree": "^11.2.0",
         "fast-glob": "^3.3.3",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.8"
+        "semver": "^7.3.8",
+        "tinyglobby": "^0.2.17"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
@@ -7820,7 +7821,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -12771,7 +12771,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14742,7 +14741,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
         "espree": "^11.2.0",
-        "is-glob": "^4.0.3",
         "semver": "^7.3.8",
         "tinyglobby": "^0.2.17"
       },
@@ -8578,6 +8577,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8597,6 +8597,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-scope": "^9.1.2",
     "eslint-visitor-keys": "^5.0.1",
     "espree": "^11.2.0",
-    "is-glob": "^4.0.3",
     "semver": "^7.3.8",
     "tinyglobby": "^0.2.17"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-scope": "^9.1.2",
     "eslint-visitor-keys": "^5.0.1",
     "espree": "^11.2.0",
-    "fast-glob": "^3.3.3",
     "is-glob": "^4.0.3",
     "semver": "^7.3.8",
     "tinyglobby": "^0.2.17"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "espree": "^11.2.0",
     "fast-glob": "^3.3.3",
     "is-glob": "^4.0.3",
-    "semver": "^7.3.8"
+    "semver": "^7.3.8",
+    "tinyglobby": "^0.2.17"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/src/parser/ts-for-v5/resolve-project-list.ts
+++ b/src/parser/ts-for-v5/resolve-project-list.ts
@@ -3,7 +3,7 @@
  * Code updated to exclude caching.
  */
 
-import fastGlob from "fast-glob";
+import { globSync } from "tinyglobby";
 import isGlob from "is-glob";
 import * as path from "path";
 import { createRequire } from "module";
@@ -11,8 +11,6 @@ import { createRequire } from "module";
 import type { ParserOptions } from "@typescript-eslint/types";
 import type { TSESTreeOptions } from "@typescript-eslint/typescript-estree";
 import type { TS } from "../../types";
-
-const { sync: globSync } = fastGlob;
 
 /**
  * Normalizes, sanitizes, resolves and filters the provided project paths
@@ -66,6 +64,7 @@ export function resolveProjectList(
           ? []
           : globSync([...globProjects, ...projectFolderIgnoreList], {
               cwd: options.tsconfigRootDir,
+              expandDirectories: false,
             }),
       )
       .map((project) =>

--- a/src/parser/ts-for-v5/resolve-project-list.ts
+++ b/src/parser/ts-for-v5/resolve-project-list.ts
@@ -41,15 +41,7 @@ export function resolveProjectList(
 
   const projectFolderIgnoreList = (
     options.projectFolderIgnoreList ?? ["**/node_modules/**"]
-  )
-    .reduce<string[]>((acc, folder) => {
-      if (typeof folder === "string") {
-        acc.push(folder);
-      }
-      return acc;
-    }, [])
-    // prefix with a ! for not match glob
-    .map((folder) => (folder.startsWith("!") ? folder : `!${folder}`));
+  ).filter((folder) => typeof folder === "string");
 
   // Transform glob patterns into paths
   const nonGlobProjects = sanitizedProjects.filter(
@@ -62,9 +54,10 @@ export function resolveProjectList(
       .concat(
         globProjects.length === 0
           ? []
-          : globSync([...globProjects, ...projectFolderIgnoreList], {
+          : globSync(globProjects, {
               cwd: options.tsconfigRootDir,
               expandDirectories: false,
+              ignore: projectFolderIgnoreList,
             }),
       )
       .map((project) =>

--- a/src/parser/ts-for-v5/resolve-project-list.ts
+++ b/src/parser/ts-for-v5/resolve-project-list.ts
@@ -3,8 +3,7 @@
  * Code updated to exclude caching.
  */
 
-import { globSync } from "tinyglobby";
-import isGlob from "is-glob";
+import { globSync, isDynamicPattern as isGlob } from "tinyglobby";
 import * as path from "path";
 import { createRequire } from "module";
 


### PR DESCRIPTION
fast-glob and is-glob together introduce 18 extra dependencies at 500+ KB. It's also not as fast compared to tinyglobby, which is offered as a replacement (see e.g. [on e18e](https://e18e.dev/docs/replacements/fast-glob.html)).

This PR replaces fast-glob with tinyglobby in `resolve-project-list.ts`. [The original file](https://github.com/typescript-eslint/typescript-eslint/blob/v8.62.0/packages/typescript-estree/src/parseSettings/resolveProjectList.ts) also uses tinyglobby now (https://github.com/typescript-eslint/typescript-eslint/pull/11740), so I just copied the relevant parts of the code over. That's also where I found out that `is-glob` can be replaced, too.

I also migrated from manual creation of exclude filters to using `exclude`, like in the original code.