### PR TITLE
Fix failing main workflows

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -41,6 +41,6 @@ jobs:
         uses: changesets/action@v2.0.0
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
+          publish-script: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'ota-meshi/astro-eslint-parser'
+    if: github.repository == 'ota-meshi/astro-eslint-parser' && github.event.workflow_run.conclusion == 'success'
     name: Update comment
     runs-on: ubuntu-latest
     steps:

--- a/explorer-v3/astro.config.mjs
+++ b/explorer-v3/astro.config.mjs
@@ -1,7 +1,9 @@
 import { defineConfig } from "astro/config";
 import svelte from "@astrojs/svelte";
 import { resolve } from "path";
-import { version as monacoVersion } from "monaco-editor/package.json";
+import monacoPackage from "./node_modules/monaco-editor/package.json" with { type: "json" };
+
+const { version: monacoVersion } = monacoPackage;
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
This fixes the three workflow failures currently reported against `main`.

Changesets Action v2 renamed the `publish` input, so the release workflow now uses `publish-script`. Monaco Editor 0.56 no longer exposes `package.json` through the bare package subpath, so the explorer config imports that direct dependency by relative path with a JSON import attribute.

The pkg.pr.new comment workflow now runs only when its source workflow succeeds. Failed source runs do not upload the `output` artifact, so attempting to download it only created a second, misleading failure.
